### PR TITLE
[docker] Build an image with the compiled command

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM rust:1.49-alpine as builder
+
+RUN apk add --no-cache musl-dev
+
+WORKDIR /usr/local/src/aws-lambda-rie-gateway
+
+COPY . .
+
+RUN cargo install --path .
+
+FROM alpine:latest
+
+ENV GATEWAY_PORT=8080
+
+EXPOSE $GATEWAY_PORT
+ENTRYPOINT aws-lambda-rie-gateway --bind 0.0.0.0:$GATEWAY_PORT --target-url $TARGET_URL
+
+COPY --from=builder /usr/local/cargo/bin/aws-lambda-rie-gateway /usr/local/bin/aws-lambda-rie-gateway

--- a/README.md
+++ b/README.md
@@ -8,3 +8,8 @@ Convert HTTP request to API Gateway payload for [aws-lambda-rie](https://github.
         - https://github.com/aws/aws-lambda-runtime-interface-emulator
 2. Start aws-lambda-rie-gateway: `cargo run`
 3. Then you can access Lambda for API Gateway with normal HTTP request: `curl http://localhost:8080/hello`
+
+# Usage Docker Image
+1. Clone this repository
+2. Then `docker build --tag aws-lambda-rie-gateway`
+3. Execute with `docker run --rm --env TARGET_URL=http://rie_app:8080 --publish 8080:8080 aws-lambda-rie-gateway`


### PR DESCRIPTION
This image REQUIRE an environment variable called TARGET_URL with the URL to the RIE endpoint like "http://rie_app:8080"

It would be nice to have an input value control when $TARGET_URL is not defined or does not have a well formatted value but I don't know rust and I don't have the time for this.

Close #1