### PR TITLE
feat(base64): adding base64 encoded response support

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -158,7 +158,10 @@ async fn handle(
                         Ok(builder.body(hyper::Body::from(decoded_bytes))?)
                     }
                     Err(e) => {
-                        tracing::warn!("Lambda response signaled it was base64, but could not decode it: {}", e);
+                        tracing::warn!(
+                            "Lambda response signaled it was base64, but could not decode it: {}",
+                            e
+                        );
                         Ok(builder.body(hyper::Body::from(body))?)
                     }
                 }
@@ -166,8 +169,6 @@ async fn handle(
                 Ok(builder.body(hyper::Body::from(body))?)
             }
         }
-        None => {
-            Ok(builder.body(hyper::Body::from(body))?)
-        }
+        None => Ok(builder.body(hyper::Body::from(body))?),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use aws_lambda_events::apigw::{
     ApiGatewayV2httpRequest, ApiGatewayV2httpRequestContext,
     ApiGatewayV2httpRequestContextHttpDescription, ApiGatewayV2httpResponse,
 };
+use base64::decode;
 use chrono::Utc;
 use clap::Parser as _;
 use futures::stream::TryStreamExt as _;
@@ -148,5 +149,24 @@ async fn handle(
         Vec::new()
     };
 
-    Ok(builder.body(hyper::Body::from(body))?)
+    match lambda_response.is_base64_encoded {
+        Some(value) => {
+            if value {
+                match decode(&body) {
+                    Ok(decoded_bytes) => {
+                        // Use the decoded bytes as needed
+                        Ok(builder.body(hyper::Body::from(decoded_bytes))?)
+                    }
+                    Err(e) => {
+                        Ok(builder.body(hyper::Body::from(body))?)
+                    }
+                }
+            } else {
+                Ok(builder.body(hyper::Body::from(body))?)
+            }
+        }
+        None => {
+            Ok(builder.body(hyper::Body::from(body))?)
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,6 +158,7 @@ async fn handle(
                         Ok(builder.body(hyper::Body::from(decoded_bytes))?)
                     }
                     Err(e) => {
+                        tracing::warn!("Lambda response signaled it was base64, but could not decode it: {}", e);
                         Ok(builder.body(hyper::Body::from(body))?)
                     }
                 }


### PR DESCRIPTION
## Goal

I have a lambda that returns a base64 response I was testing. This adds in the support for those types of responses. I have tested this against my own environment.